### PR TITLE
changed conditional import for struct and ustruct

### DIFF
--- a/adafruit_max31855.py
+++ b/adafruit_max31855.py
@@ -28,8 +28,10 @@ This is a CircuitPython driver for the Maxim Integrated MAX31855 thermocouple
 amplifier module.
 
 """
-
-import ustruct
+try:
+    import struct
+except:
+    import ustruct as struct
 
 from adafruit_bus_device.spi_device import SPIDevice
 
@@ -54,7 +56,7 @@ class MAX31855:
             raise RuntimeError("short circuit to power")
         if self.data[1] & 0x01:
             raise RuntimeError("faulty reading")
-        temp, refer = ustruct.unpack('>hh', self.data)
+        temp, refer = struct.unpack('>hh', self.data)
         refer >>= 4
         temp >>= 2
         if internal:

--- a/adafruit_max31855.py
+++ b/adafruit_max31855.py
@@ -30,7 +30,7 @@ amplifier module.
 """
 try:
     import struct
-except:
+except ImportError:
     import ustruct as struct
 
 from adafruit_bus_device.spi_device import SPIDevice


### PR DESCRIPTION
as a result of Refine `ustruct` into `struct` in shared-bindings and shared-module. #205 