### PR TITLE
Ignore the board module imports in .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -155,7 +155,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=board
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.


### PR DESCRIPTION
Submitting PR for this, since the adabot patch failed for this single library. 

Here is the error from adabot:
```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: error: At least 1 approving review is required by reviewers with write access.
To https://github.com/adafruit/Adafruit_CircuitPython_MAX31855.git
! [remote rejected] master -> master (protected branch hook declined)
error: failed to push some refs to 'https://github.com/adafruit/Adafruit_CircuitPython_MAX31855.git
```