### PR TITLE
Fix conversion factor

### DIFF
--- a/adafruit_max31855.py
+++ b/adafruit_max31855.py
@@ -88,4 +88,4 @@ class MAX31855:
     @property
     def reference_temperature(self):
         """Internal reference temperature in degrees Celsius."""
-        return self._read(True) * 0.625
+        return self._read(True) * 0.0625


### PR DESCRIPTION
Simply typo fix for #10.

**BEFORE**
```python
>>> import board, busio, digitalio
>>> import adafruit_max31855
>>> spi = busio.SPI(board.D13, board.D12, None)
>>> cs =digitalio.DigitalInOut(board.D5)
>>> max31855 = adafruit_max31855.MAX31855(spi, cs)
>>> max31855.temperature
22.75
>>> max31855.reference_temperature
230.625
>>> 
```
**AFTER**
```python
>>> import board, busio, digitalio
>>> import adafruit_max31855
>>> spi = busio.SPI(board.D13, board.D12, None)
>>> cs =digitalio.DigitalInOut(board.D5)
>>> max31855 = adafruit_max31855.MAX31855(spi, cs)
>>> max31855.temperature
25.75
>>> max31855.reference_temperature
22.875
>>> 
```