### PR TITLE
Add NIST based temperature calculation

### DIFF
--- a/adafruit_max31855.py
+++ b/adafruit_max31855.py
@@ -43,6 +43,7 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
 """
+from math import exp, pow
 try:
     import struct
 except ImportError:
@@ -89,3 +90,81 @@ class MAX31855:
     def reference_temperature(self):
         """Internal reference temperature in degrees Celsius."""
         return self._read(True) * 0.0625
+
+    @property
+    def temperatureNIST(self):
+        """
+        Thermocouple temperature in degrees Celsius, computed using
+        raw voltages and NIST approximation for Type K, see:
+        https://srdata.nist.gov/its90/download/type_k.tab
+        """
+        # temperature of remote thermocouple junction
+        TR = self.temperature
+        # temperature of device (cold junction)
+        TAMB = self.reference_temperature
+        # thermocouple voltage based on MAX31855's uV/degC for type K (table 1)
+        VOUT = 0.041276 * (TR - TAMB)
+        # cold junction equivalent thermocouple voltage
+        if TAMB >= 0:
+            VREF =(-0.176004136860E-01 +
+                    0.389212049750E-01 * TAMB +
+                    0.185587700320E-04 * pow(TAMB,2) +
+                   -0.994575928740E-07 * pow(TAMB,3) +
+                    0.318409457190E-09 * pow(TAMB,4) +
+                   -0.560728448890E-12 * pow(TAMB,5) +
+                    0.560750590590E-15 * pow(TAMB,6) +
+                   -0.320207200030E-18 * pow(TAMB,7) +
+                    0.971511471520E-22 * pow(TAMB,8) +
+                   -0.121047212750E-25 * pow(TAMB,9) +
+                    0.1185976 * exp(-0.1183432E-03 * pow(TAMB - 0.1269686E+03, 2)))
+        else:
+            VREF =( 0.394501280250E-01 * TAMB +
+                    0.236223735980E-04 * pow(TAMB, 2) +
+                   -0.328589067840E-06 * pow(TAMB, 3) +
+                   -0.499048287770E-08 * pow(TAMB, 4) +
+                   -0.675090591730E-10 * pow(TAMB, 5) +
+                   -0.574103274280E-12 * pow(TAMB, 6) +
+                   -0.310888728940E-14 * pow(TAMB, 7) +
+                   -0.104516093650E-16 * pow(TAMB, 8) +
+                   -0.198892668780E-19 * pow(TAMB, 9) +
+                   -0.163226974860E-22 * pow(TAMB, 10))
+        # total thermoelectric voltage
+        VTOTAL = VOUT + VREF
+        # determine coefficients
+        # https://srdata.nist.gov/its90/type_k/kcoefficients_inverse.html
+        if -5.891 <= VTOTAL <=0:
+            DCOEF = (0.0000000E+00,
+                     2.5173462E+01,
+                    -1.1662878E+00,
+                    -1.0833638E+00,
+                    -8.9773540E-01,
+                    -3.7342377E-01,
+                    -8.6632643E-02,
+                    -1.0450598E-02,
+                    -5.1920577E-04)
+        elif 0 < VTOTAL <= 20.644:
+            DCOEF = (0.000000E+00,
+                     2.508355E+01,
+                     7.860106E-02,
+                    -2.503131E-01,
+                     8.315270E-02,
+                    -1.228034E-02,
+                     9.804036E-04,
+                    -4.413030E-05,
+                     1.057734E-06,
+                    -1.052755E-08)
+        elif 20.644 < VTOTAL <= 54.886:
+            DCOEF = (-1.318058E+02,
+                      4.830222E+01,
+                     -1.646031E+00,
+                      5.464731E-02,
+                     -9.650715E-04,
+                      8.802193E-06,
+                     -3.110810E-08)
+        else:
+            raise RuntimeError("Total thermoelectric voltage out of range:{}".format(VTOTAL))
+        # compute temperature
+        TEMPERATURE = 0
+        for n, c in enumerate(DCOEF):
+            TEMPERATURE += c * pow(VTOTAL, n)
+        return TEMPERATURE

--- a/adafruit_max31855.py
+++ b/adafruit_max31855.py
@@ -43,7 +43,7 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
 """
-from math import exp, pow
+import math
 try:
     import struct
 except ImportError:
@@ -109,26 +109,26 @@ class MAX31855:
         if TAMB >= 0:
             VREF =(-0.176004136860E-01 +
                     0.389212049750E-01 * TAMB +
-                    0.185587700320E-04 * pow(TAMB, 2) +
-                   -0.994575928740E-07 * pow(TAMB, 3) +
-                    0.318409457190E-09 * pow(TAMB, 4) +
-                   -0.560728448890E-12 * pow(TAMB, 5) +
-                    0.560750590590E-15 * pow(TAMB, 6) +
-                   -0.320207200030E-18 * pow(TAMB, 7) +
-                    0.971511471520E-22 * pow(TAMB, 8) +
-                   -0.121047212750E-25 * pow(TAMB, 9) +
-                    0.1185976 * exp(-0.1183432E-03 * pow(TAMB - 0.1269686E+03, 2)))
+                    0.185587700320E-04 * math.pow(TAMB, 2) +
+                   -0.994575928740E-07 * math.pow(TAMB, 3) +
+                    0.318409457190E-09 * math.pow(TAMB, 4) +
+                   -0.560728448890E-12 * math.pow(TAMB, 5) +
+                    0.560750590590E-15 * math.pow(TAMB, 6) +
+                   -0.320207200030E-18 * math.pow(TAMB, 7) +
+                    0.971511471520E-22 * math.pow(TAMB, 8) +
+                   -0.121047212750E-25 * math.pow(TAMB, 9) +
+                    0.1185976 * math.exp(-0.1183432E-03 * math.pow(TAMB - 0.1269686E+03, 2)))
         else:
             VREF =( 0.394501280250E-01 * TAMB +
-                    0.236223735980E-04 * pow(TAMB, 2) +
-                   -0.328589067840E-06 * pow(TAMB, 3) +
-                   -0.499048287770E-08 * pow(TAMB, 4) +
-                   -0.675090591730E-10 * pow(TAMB, 5) +
-                   -0.574103274280E-12 * pow(TAMB, 6) +
-                   -0.310888728940E-14 * pow(TAMB, 7) +
-                   -0.104516093650E-16 * pow(TAMB, 8) +
-                   -0.198892668780E-19 * pow(TAMB, 9) +
-                   -0.163226974860E-22 * pow(TAMB, 10))
+                    0.236223735980E-04 * math.pow(TAMB, 2) +
+                   -0.328589067840E-06 * math.pow(TAMB, 3) +
+                   -0.499048287770E-08 * math.pow(TAMB, 4) +
+                   -0.675090591730E-10 * math.pow(TAMB, 5) +
+                   -0.574103274280E-12 * math.pow(TAMB, 6) +
+                   -0.310888728940E-14 * math.pow(TAMB, 7) +
+                   -0.104516093650E-16 * math.pow(TAMB, 8) +
+                   -0.198892668780E-19 * math.pow(TAMB, 9) +
+                   -0.163226974860E-22 * math.pow(TAMB, 10))
         # total thermoelectric voltage
         VTOTAL = VOUT + VREF
         # determine coefficients
@@ -167,5 +167,5 @@ class MAX31855:
         # compute temperature
         TEMPERATURE = 0
         for n, c in enumerate(DCOEF):
-            TEMPERATURE += c * pow(VTOTAL, n)
+            TEMPERATURE += c * math.pow(VTOTAL, n)
         return TEMPERATURE

--- a/adafruit_max31855.py
+++ b/adafruit_max31855.py
@@ -92,12 +92,13 @@ class MAX31855:
         return self._read(True) * 0.0625
 
     @property
-    def temperatureNIST(self):
+    def temperature_NIST(self):
         """
         Thermocouple temperature in degrees Celsius, computed using
         raw voltages and NIST approximation for Type K, see:
         https://srdata.nist.gov/its90/download/type_k.tab
         """
+        # pylint: disable=bad-whitespace, bad-continuation, invalid-name
         # temperature of remote thermocouple junction
         TR = self.temperature
         # temperature of device (cold junction)
@@ -108,14 +109,14 @@ class MAX31855:
         if TAMB >= 0:
             VREF =(-0.176004136860E-01 +
                     0.389212049750E-01 * TAMB +
-                    0.185587700320E-04 * pow(TAMB,2) +
-                   -0.994575928740E-07 * pow(TAMB,3) +
-                    0.318409457190E-09 * pow(TAMB,4) +
-                   -0.560728448890E-12 * pow(TAMB,5) +
-                    0.560750590590E-15 * pow(TAMB,6) +
-                   -0.320207200030E-18 * pow(TAMB,7) +
-                    0.971511471520E-22 * pow(TAMB,8) +
-                   -0.121047212750E-25 * pow(TAMB,9) +
+                    0.185587700320E-04 * pow(TAMB, 2) +
+                   -0.994575928740E-07 * pow(TAMB, 3) +
+                    0.318409457190E-09 * pow(TAMB, 4) +
+                   -0.560728448890E-12 * pow(TAMB, 5) +
+                    0.560750590590E-15 * pow(TAMB, 6) +
+                   -0.320207200030E-18 * pow(TAMB, 7) +
+                    0.971511471520E-22 * pow(TAMB, 8) +
+                   -0.121047212750E-25 * pow(TAMB, 9) +
                     0.1185976 * exp(-0.1183432E-03 * pow(TAMB - 0.1269686E+03, 2)))
         else:
             VREF =( 0.394501280250E-01 * TAMB +


### PR DESCRIPTION
For #12. Adds a fancier temperature calculation which the older library had:
https://github.com/adafruit/Adafruit_Python_MAX31855/blob/master/Adafruit_MAX31855/MAX31855.py#L99

```console
$ python3
Python 3.6.8 (default, Aug 20 2019, 17:12:48) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board, digitalio, adafruit_max31855
>>> cs = digitalio.DigitalInOut(board.C0)
>>> spi = board.SPI()
>>> max = adafruit_max31855.MAX31855(spi, cs)
>>> max.temperature
25.5
>>> max.temperature_NIST
25.46810379959506
>>>
```