### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_max31855.py
+++ b/adafruit_max31855.py
@@ -100,7 +100,7 @@ class MAX31855:
         raw voltages and NIST approximation for Type K, see:
         https://srdata.nist.gov/its90/download/type_k.tab
         """
-        # pylint: disable=bad-whitespace, bad-continuation, invalid-name
+        # pylint: disable=invalid-name
         # temperature of remote thermocouple junction
         TR = self.temperature
         # temperature of device (cold junction)


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0. (ditto bad-continuation)